### PR TITLE
rename modextraalias to modaliases

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -829,7 +829,7 @@ class EasyBlock(object):
             elif not isinstance(value, (tuple, list)):
                 self.log.error("modextrapaths dict value %s (type: %s) is not a list or tuple" % (value, type(value)))
             txt += self.moduleGenerator.prepend_paths(key, value)
-        for (key, value) in self.cfg['modextraalias'].items():
+        for (key, value) in self.cfg['modaliases'].items():
             txt += self.moduleGenerator.set_alias(key, value)
 
         self.log.debug("make_module_extra added this: %s" % txt)

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -162,7 +162,7 @@ DEFAULT_CONFIG = {
     # MODULES easyconfig parameters
     'modextrapaths': [{}, "Extra paths to be prepended in module file", MODULES],
     'modextravars': [{}, "Extra environment variables to be added to module file", MODULES],
-    'modextraalias': [{}, "Extra alias to be added to module file", MODULES],
+    'modaliases': [{}, "Aliases to be defined in module file", MODULES],
     'moduleclass': ['base', 'Module class to be used for this software', MODULES],
     'moduleforceunload': [False, 'Force unload of all modules when loading the extension', MODULES],
     'moduleloadnoconflict': [False, "Don't check for conflicts, unload other versions instead ", MODULES],


### PR DESCRIPTION
@pescobar: minor tweak to https://github.com/hpcugent/easybuild-framework/pull/952, I feel the `extra` doesn't make much sense (since EB won't define any aliases itself), and it should be plural hence `aliases`

enhanced unit tests are fine, nice job

please merge this in ASAP so we can include this in EasyBuild v1.14.0
